### PR TITLE
Added error catching for when user does not exist.

### DIFF
--- a/bluebird/scraper.py
+++ b/bluebird/scraper.py
@@ -121,7 +121,7 @@ class BlueBird:
                 error_message = data['errors'][0]['message']
                 if error_message == 'Forbidden.':
                     self._pop_guest_token()
-                elif error_message == 'Bad request.':
+                elif error_message == 'Bad request.' or error_message == "User not found.":
                     return
                 else:
                     self._rotate_guest_token()


### PR DESCRIPTION
When user does not exist, calling `get_user_by_id` or `get_user_by_name` will cause Bluebird to exhaust itself. Added simple check for "User does not exist" error. 